### PR TITLE
Update ci.yml to use codecov token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
           name: codecov-umbrella
           verbose: true
           files: coverage_${{ matrix.python-version }}.xml
+          token: ${{ env.secrets.CODECOV_TOKEN }}
           # dry_run: true
 
   #finish:


### PR DESCRIPTION
Adding token to avoid intermittent failures due to codecov upload errors, as noted here: https://github.com/codecov/feedback/issues/126