### PR TITLE
Python text file encoding

### DIFF
--- a/dassh/reactor.py
+++ b/dassh/reactor.py
@@ -1288,7 +1288,7 @@ class Reactor(LoggedClass):
         out += flow.generate(self)
 
         # Write to output file
-        with open(os.path.join(self.path, 'dassh.out'), 'w') as f:
+        with open(os.path.join(self.path, 'dassh.out'), 'w', encoding='utf8') as f:
             f.write(out)
 
     def write_output_summary(self, hotspot_data=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ pytest==6.2.4
 pytest-cov==2.12.0
 matplotlib>=3.2
 numpy>=1.18
-coverage==7.2.2
+coverage==7.2.2; python_version > '3.6'
+coverage==6.2; python_version <= '3.6'
 dill==0.3.4
 packaging>=20.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ pytest==6.2.4
 pytest-cov==2.12.0
 matplotlib>=3.2
 numpy>=1.18
-codecov==2.1.11
+coverage==7.2.2
 dill==0.3.4
 packaging>=20.0


### PR DESCRIPTION
The DASSH output file contains a unicode character (check mark) in one of the tables. Right now, no specific text encoding is specified for this file. Generally Python can figure out if it is ASCII or Unicode or other, but sometimes it struggles. In the PyARC workflow with some updated python environment packages, I am finding that it can no longer properly identify the file as needing unicode encoding rather than ascii and it fails to generate the output file because it doesn't know how to write the check mark unicode character. This one-line fix should fix that error.

It also appears the develop and master branches here are out of sync and need to be fixed before this is merged.