### PR TITLE
Add contributing guidelines

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at pyarc@anl.gov. All complaints will
+be reviewed and investigated and will result in a response that is deemed
+necessary and appropriate to the circumstances. The project team is obligated to
+maintain confidentiality with regard to the reporter of an incident. However,
+note that some project team members may have a legal obligation to report
+certain forms of harassment because of their affiliation (for example, staff and
+faculty at universities in the United States). Further details of specific
+enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at pyarc@anl.gov. All complaints will
+reported by contacting the project team at nera-software@anl.gov. All complaints will
 be reviewed and investigated and will result in a response that is deemed
 necessary and appropriate to the circumstances. The project team is obligated to
 maintain confidentiality with regard to the reporter of an incident. However,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing Guidelines
+
+This documentation provides guidelines for new DASSH developers to learn about development practices.
+
+## Important Note 
+
+This python version of DASSH (herein referred to DASSH-py) is now considered obsolete and has been replaced with the Fortran version of DASSH (herein referred to as DASSH-F).
+DASSH-F can be acquired by emailing `nera-software@anl.gov` to apply for access.
+As such, DASSH-py is no longer actively being maintained or updated.
+External developers seeking to contribute to DASSH-py can do so independently following open-source development principles.
+However, there is no guarantee that any developments will be reviewed and accepted back into this repository by ANL staff. 
+
+## Developer Code of Conduct
+
+The code of conduct for developer interactions can be found here.
+Please report any unacceptable behavior to `nera-software@anl.gov`.
+
+## Making Contributions
+
+### Start a Discussion
+
+[Create an issue](https://github.com/dassh-dev/dassh/issues) to report bugs or feature requests (please note that due to DASSH-py becoming obsolete, feature requests are not likely to be supported). 
+For larger contributions, please email `nera-software@anl.gov` to discuss how to best approach the development. 
+
+### Version Control Workflow 
+
+1. Fork this repository to your own workspace. 
+2. Create a new branch to develop your feature or bug fix. 
+3. Create commits with descriptive yet concise commit messages. 
+4. Ensure all tests pass locally and that your code follows the style guide standards. 
+5. Create a [Pull Request (PR)](https://github.com/dassh-dev/dassh/pulls) into the `develop` branch of this repository to propose your changes and undergo review. 
+6. Changes that are reviewed and approved by the development team will be merged into the `develop` branch of DASSH.
+
+### Testing
+
+All new features developed must have tests added to demonstrate correct behavior.
+These tests should also include testing for errors or undesirable code behavior.
+No existing tests should fail as the result of code changes, but some may be amended if the proposed changes do impact past behavior or results. 
+If the contribution is a bug fix, tests should be updated accordingly, and in some cases, new tests should be added. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ However, there is no guarantee that any developments will be reviewed and accept
 
 ## Developer Code of Conduct
 
-The code of conduct for developer interactions can be found here.
+The code of conduct for developer interactions can be found [here](./CODE_OF_CONDUCT.md).
 Please report any unacceptable behavior to `nera-software@anl.gov`.
 
 ## Making Contributions

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@
 
 The Ducted Assembly Steady State Heat Transfer Software (DASSH) is an open-source tool for calculating temperature and flow distributions in hexagonal, ducted assemblies comprised of wire-wrapped pin bundles. DASSH is intended for use during the design process to provide a rapid assessment of the flow and temperature distribution, especially when assembly designs are in their early stages and not fully developed.
 
+## Important Note 
+
+This python version of DASSH is now considered obsolete and has been replaced with the Fortran version of DASSH (herein referred to as DASSH-F).
+DASSH-F can be acquired by emailing `nera-software@anl.gov` to apply for access.
+As such, this repository is no longer actively being maintained or updated.
+
 ## Installation
 DASSH requires Python 3.6+. Detailed installation instructions can be found in the [user guide](https://github.com/dassh-dev/documents/blob/master/user_guide.pdf).
 
@@ -17,7 +23,12 @@ If you use DASSH in your research, please consider citing the following conferen
 * Milos Atz, Micheal A. Smith, Florent Heidet, "Ducted Assembly Steady State Heat Transfer Software (DASSH) - User Guide", ANL/NSE-21/34, Argonne National Laboratory, 2021.
 
 ## Troubleshooting and reporting bugs
-If you encounter issues installing or running DASSH or would like to report a bug, please reach out to the developer via `matz [at] anl [dot] gov`
+
+If you encounter issues installing or running DASSH or would like to report a bug, please reach out to the developer via `nera-software@anl.gov` or open an Issue.
+
+## Contributing
+
+If you would like to contribute, please refer the [guidelines here](./CONTRIBUTING.md).
 
 ## Documentation
 * User guide: https://github.com/dassh-dev/documents/blob/master/user_guide.pdf


### PR DESCRIPTION
Added contributing guidelines and code of conduct for the repository. I added the note and reference to the contributing guidelines in the README as well. 

This PR is opened into `master` directly so that it is visible on the default branch. Note that per guidelines all other PRs are to be made into `develop`.